### PR TITLE
[DEX-636] add the ability to have no cpu limits

### DIFF
--- a/charts/microservice/Chart.yaml
+++ b/charts/microservice/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: Microservice template
 name: microservice
-version: 1.7.23
+version: 1.7.24

--- a/charts/microservice/templates/deployments.yaml
+++ b/charts/microservice/templates/deployments.yaml
@@ -59,7 +59,9 @@ spec:
               cpu: {{ .Values.autoscaling.min_cpu }}
               memory: {{ .Values.autoscaling.min_memory }}
             limits:
+            {{- if .Values.autoscaling.max_cpu }}
               cpu: {{ .Values.autoscaling.max_cpu }}
+            {{- end }}
               memory: {{ .Values.autoscaling.max_memory }}
         {{- end }}
         {{- if eq .Values.debug.enabled true }}

--- a/charts/microservice/values.yaml
+++ b/charts/microservice/values.yaml
@@ -66,7 +66,7 @@ autoscaling:
   min_memory: 100Mi
   max_memory: 200Mi
   min_cpu: 100m
-  max_cpu: 200m
+  max_cpu: null
 
 ## For scale-up/down operation, define the number of replicas of the app.
 ## We recommend for the minimum to be 2 or more, unless there is a specific need for a single replica.


### PR DESCRIPTION
With this change, if a microservice has no max_cpu value set, or sets it to null, it will give the service no cpu limit, which will allow us to avoid any cpu throttling on the services. 

All microservices are currently setting a max_cpu value for all envs, so changing the default value in the values.yaml file has no effect on existing services. 