### PR TITLE
[DEVOPS-269] Convert migration Job to Helm pre-upgrade hook

### DIFF
--- a/charts/microservice/Chart.yaml
+++ b/charts/microservice/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: Microservice template
 name: microservice
-version: 1.10.1
+version: 1.11.0

--- a/charts/microservice/templates/jobs.yaml
+++ b/charts/microservice/templates/jobs.yaml
@@ -2,13 +2,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-migrator-{{ randAlphaNum 5 | lower }}
+  name: {{ .Release.Name }}-migrator
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "migration.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   backoffLimit: 0

--- a/charts/microservice/templates/jobs.yaml
+++ b/charts/microservice/templates/jobs.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "migration.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   backoffLimit: 0
   template:


### PR DESCRIPTION
## Summary

- Adds `helm.sh/hook` annotations (`pre-install,pre-upgrade`, weight `-5`, delete policy `before-hook-creation`) to the microservice migration Job so Helm runs it as a pre-upgrade hook.
- Bumps chart version `1.10.1 -> 1.11.0`.

Combined with `helm upgrade --atomic` in the monorepo workflow, Helm will now block on the migration Job and auto-rollback on failure, replacing the custom polling logic in `build-and-deploy.yaml` (monorepo PR follows separately).

### Why `before-hook-creation`?

- K8s won't allow duplicate Job names, so the prior Job must be removed before re-creation.
- It preserves failed Jobs until the next deploy, which keeps logs available for debugging.
- We intentionally do **not** use `hook-succeeded` — that would delete the Job immediately on success and make logs harder to retrieve.

### End-to-end flow

```
helm upgrade --install --atomic --timeout 10m
  ├── 1. Delete previous migration Job (before-hook-creation)
  ├── 2. Create new migration Job (pre-upgrade hook)
  ├── 3. Wait for Job to complete (success or fail)
  │     ├── success -> proceed to step 4
  │     └── fail -> automatic rollback, helm exits non-zero
  └── 4. Apply Deployment + other resources (app pods roll out)
```

Ticket: [DEVOPS-269](https://nursa.atlassian.net/browse/DEVOPS-269)

## Test plan

- [ ] `helm template` renders the Job with the new annotations (verified locally).
- [ ] In a stage environment, deploy a chart consumer with `migration.enabled=true` and confirm the Job runs before the Deployment and is retained after success.
- [ ] Force a migration failure in stage and confirm `helm upgrade --atomic` exits non-zero and the release rolls back.
- [ ] Confirm `migration.enabled=false` still produces no Job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVOPS-269]: https://nursa.atlassian.net/browse/DEVOPS-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ