### PR TITLE
feat(microservice): add linked_services list for multi-component sidekicks

### DIFF
--- a/charts/microservice/Chart.yaml
+++ b/charts/microservice/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: Microservice template
 name: microservice
-version: 1.11.0
+version: 1.12.0

--- a/charts/microservice/templates/_helpers.tpl
+++ b/charts/microservice/templates/_helpers.tpl
@@ -107,3 +107,27 @@ timestamp: {{ now | unixEpoch | quote }}
 "helm.sh/hook-weight": "0"
 "helm.sh/hook-delete-policy": hook-failed
 {{- end }}
+
+{{/*
+Parameterized helpers for the new `linked_services` (plural) list. Callers pass a dict
+with `name` (the service name) and `ctx` (root context, for labels that depend on global).
+The legacy `linked_service.*` helpers above stay for backwards compat with single-object users.
+*/}}
+
+{{- define "linked_services.annotations" -}}
+{{- $name := .name -}}
+timestamp: {{ now | unixEpoch | quote }}
+"ad.datadoghq.com/{{ $name }}.logs": |-
+  [{
+    "source":"{{ $name }}",
+    "tags":["pod_ip:%%host%%"]
+  }]
+{{- end }}
+
+{{- define "linked_services.labels" -}}
+{{- $name := .name -}}
+{{- with .ctx -}}
+{{ include "common.labels" . | trim }}
+{{- end }}
+"tags.datadoghq.com/service": {{ $name }}
+{{- end }}

--- a/charts/microservice/templates/linked_service_deployment.yaml
+++ b/charts/microservice/templates/linked_service_deployment.yaml
@@ -78,3 +78,85 @@ spec:
               secretProviderClass: {{ printf "gcp-secrets-%s" (include "appname" .)}}
       {{- end }}
 {{- end }}
+
+{{- range $svc := .Values.linked_services }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $svc.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ $svc.name }}
+{{ include "linked_services.labels" (dict "name" $svc.name "ctx" $) | nindent 4 }}
+  annotations:
+{{ include "linked_services.annotations" (dict "name" $svc.name) | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $svc.name }}
+  replicas: {{ $svc.parameters.replicas }}
+  template:
+    metadata:
+      labels:
+        app: {{ $svc.name }}
+{{ include "linked_services.labels" (dict "name" $svc.name "ctx" $) | nindent 8 }}
+      annotations:
+{{ include "linked_services.annotations" (dict "name" $svc.name) | nindent 8 }}
+    spec:
+      serviceAccountName: {{ $svc.parameters.serviceAccountName | default (include "appname" $) }}
+      containers:
+        - name: {{ $svc.name }}
+          image: {{ printf "%s:%s" $svc.parameters.image.repository (toString $svc.parameters.image.tag) }}
+          ports:
+            {{- range $port := $svc.parameters.ports }}
+            - containerPort: {{ $port.containerPort }}
+            {{- end }}
+          resources:
+            requests:
+              memory: {{ $svc.parameters.resources.min_memory }}
+              cpu: {{ $svc.parameters.resources.min_cpu }}
+            limits:
+              memory: {{ $svc.parameters.resources.max_memory }}
+              cpu: {{ $svc.parameters.resources.max_cpu }}
+          {{- $lsProbe := $svc.parameters.probeConfig | default dict }}
+          {{- if $svc.parameters.startupProbe }}
+          startupProbe:
+            {{- merge $lsProbe $svc.parameters.startupProbe | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if $svc.parameters.livenessProbe }}
+          livenessProbe:
+            {{- merge $lsProbe $svc.parameters.livenessProbe | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if $svc.parameters.readinessProbe }}
+          readinessProbe:
+            {{- merge $lsProbe $svc.parameters.readinessProbe | toYaml | nindent 12 }}
+          {{- end }}
+          env:
+            {{- range $key, $value := $svc.parameters.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- range $secret := $svc.parameters.secrets }}
+            - name: {{ upper $secret | replace "-" "_" }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secret | replace "_" "-" }}
+                  key: value
+                  optional: false
+            {{- end }}
+          {{- if $svc.parameters.secrets }}
+          volumeMounts:
+            - name: gcp-secret-store-vol
+              mountPath: "/var/secrets-store"
+          {{- end }}
+      {{- if $svc.parameters.secrets }}
+      volumes:
+        - name: gcp-secret-store-vol
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ printf "gcp-secrets-%s" (include "appname" $) }}
+      {{- end }}
+{{- end }}

--- a/charts/microservice/templates/linked_service_service.yaml
+++ b/charts/microservice/templates/linked_service_service.yaml
@@ -17,3 +17,24 @@ spec:
       targetPort: {{ $port.containerPort }}
     {{- end }}
 {{- end }}
+
+{{- range $svc := .Values.linked_services }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $svc.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ $svc.name }}
+{{ include "linked_services.labels" (dict "name" $svc.name "ctx" $) | nindent 4 }}
+spec:
+  selector:
+    app: {{ $svc.name }}
+  ports:
+    {{- range $port := $svc.parameters.ports }}
+    - protocol: TCP
+      port: {{ $port.containerPort }}
+      targetPort: {{ $port.containerPort }}
+    {{- end }}
+{{- end }}

--- a/charts/microservice/values.yaml
+++ b/charts/microservice/values.yaml
@@ -183,5 +183,23 @@ init_container:
     - sleep
     - 10
 
+# DEPRECATED: prefer `linked_services` (list, see below). Kept for backwards compat.
 linked_service:
   enabled: false
+
+# Multiple linked services. Each entry produces one Deployment + ClusterIP Service in the
+# same Helm release as the parent microservice. Useful when the parent app needs >=1 sidekick
+# components (e.g. firecrawl-api + firecrawl-playwright + firecrawl-redis).
+#
+# Each entry has the same shape as `linked_service.parameters` plus a `name` field at the top.
+# Example:
+#   linked_services:
+#     - name: firecrawl
+#       parameters:
+#         replicas: 1
+#         image: { repository: ghcr.io/firecrawl/firecrawl, tag: "v1.x.x" }
+#         serviceAccountName: nursa-scraping
+#         ports: [{ containerPort: 3002 }]
+#         env: { USE_DB_AUTHENTICATION: "false" }
+#         resources: { min_memory: 512Mi, min_cpu: 200m, max_memory: 1Gi, max_cpu: 1 }
+linked_services: []

--- a/charts/microservice/values.yaml
+++ b/charts/microservice/values.yaml
@@ -183,7 +183,7 @@ init_container:
     - sleep
     - 10
 
-# DEPRECATED: prefer `linked_services` (list, see below). Kept for backwards compat.
+# DEPRECATED: change other places that are using this `linked_service` to use the new plural one (`linked_services`, see below).
 linked_service:
   enabled: false
 


### PR DESCRIPTION
## Summary

Adds `linked_services` (plural list) to the `microservice` chart values, alongside the existing `linked_service` (singular object). Each entry in the list renders one Deployment + ClusterIP Service in the parent app's release.

**Why:** the singular `linked_service` supports exactly one extra Deployment per ms (used by Phoenix → Gotenberg). Some apps need >=1 internal sidekick group — e.g. `nursa-scraping` needs to deploy Firecrawl, which is itself 3 components (`firecrawl-api` + `firecrawl-playwright` + `firecrawl-redis`). Without this change those 3 components would either need a custom subchart or three separate microservice releases — both heavier than one parameter.

## Backwards compatibility

The legacy `linked_service.enabled` branch is unchanged in both templates. Existing Phoenix `values-*.yaml` renders byte-identical output. A future PR can migrate Phoenix from singular → list (single-entry list) and then drop the legacy branch.

## Changes

- `Chart.yaml`: 1.11.0 → 1.12.0 (semver minor — backwards compat).
- `values.yaml`: add `linked_services: []` with documenting example. Mark old `linked_service:` as DEPRECATED.
- `templates/_helpers.tpl`: add parameterized helpers `linked_services.annotations` and `linked_services.labels` that take a `(name, ctx)` dict, so they work inside `range`. Legacy `linked_service.*` helpers untouched.
- `templates/linked_service_deployment.yaml`: append a `range \$svc := .Values.linked_services` block after the legacy \`if\`. New \`serviceAccountName\` falls back to the parent app's SA when not set per entry.
- `templates/linked_service_service.yaml`: same pattern.

## Example consumer (`nursa-scraping`)

\`\`\`yaml
linked_services:
  - name: firecrawl
    parameters:
      replicas: 1
      image: { repository: ghcr.io/firecrawl/firecrawl, tag: \"v1.x.x\" }
      ports: [{ containerPort: 3002 }]
      env:
        PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright:3000/scrape
        REDIS_URL: redis://firecrawl-redis:6379
        USE_DB_AUTHENTICATION: \"false\"
      resources: { min_memory: 512Mi, min_cpu: 200m, max_memory: 1Gi, max_cpu: 1 }
  - name: firecrawl-playwright
    parameters:
      replicas: 1
      image: { repository: ghcr.io/firecrawl/playwright-service, tag: \"latest\" }
      ports: [{ containerPort: 3000 }]
      resources: { min_memory: 1Gi, min_cpu: 500m, max_memory: 2Gi, max_cpu: 2 }
  - name: firecrawl-redis
    parameters:
      replicas: 1
      image: { repository: redis, tag: \"7-alpine\" }
      ports: [{ containerPort: 6379 }]
      resources: { min_memory: 128Mi, min_cpu: 50m, max_memory: 256Mi, max_cpu: 500m }
\`\`\`

Renders to 3 Deployments + 3 ClusterIP Services in the same release. Each is reachable from the parent app as \`http://<name>:<port>\`.

## Test plan

- [ ] \`helm lint charts/microservice\` clean.
- [ ] \`helm template charts/microservice -f <phoenix-values>.yaml\` byte-equal to 1.11.0 output (backwards-compat proof).
- [ ] \`helm template charts/microservice -f <nursa-scraping-values>.yaml\` renders 3 Deployments + 3 Services for the firecrawl trio.
- [ ] Sandbox cluster: deploy a test release with two list entries; confirm both Pods are reachable via their Service names.