### PR TITLE
[PAR-870] feat(microservice): add graceful-shutdown support

### DIFF
--- a/charts/microservice/Chart.yaml
+++ b/charts/microservice/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: Microservice template
 name: microservice
-version: 1.12.0
+version: 1.13.0

--- a/charts/microservice/templates/deployments.yaml
+++ b/charts/microservice/templates/deployments.yaml
@@ -28,6 +28,9 @@ spec:
         {{- include "common.annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ default (include "appname" .) .Values.serviceAccount }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       nodeSelector:
         iam.gke.io/gke-metadata-server-enabled: "true"
         {{- range $key,$value:= index .Values "deployment" "nodeSelector" }}
@@ -37,6 +40,10 @@ spec:
         - name: {{ .Release.Name }}
           image: {{ printf "%s:%s" .Values.image .Values.image_tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- if .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          {{- end }}
           env:
             - name: HANDLE_BROKER_MESSAGES
               value: {{ if (hasKey .Values "worker") }}{{ .Values.worker.enabled | not | quote }}{{ else }}{{ "true" | quote }}{{ end }}
@@ -170,6 +177,10 @@ spec:
         {{- include "common.annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ default (include "appname" .) .Values.serviceAccount }}
+      {{- $workerTerminationGrace := default .Values.terminationGracePeriodSeconds (dig "terminationGracePeriodSeconds" nil .Values.worker) }}
+      {{- if $workerTerminationGrace }}
+      terminationGracePeriodSeconds: {{ $workerTerminationGrace }}
+      {{- end }}
       nodeSelector:
         iam.gke.io/gke-metadata-server-enabled: "true"
         {{- $nodeSelectors := default .Values.deployment.nodeSelector (dig "deployment" "nodeSelector" nil .Values.worker) }}
@@ -180,6 +191,11 @@ spec:
         - name: {{ .Release.Name }}-worker
           image: {{ printf "%s:%s" .Values.image .Values.image_tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- $workerLifecycle := default .Values.lifecycle (dig "lifecycle" nil .Values.worker) }}
+          {{- if $workerLifecycle }}
+          lifecycle:
+            {{- toYaml $workerLifecycle | nindent 12 }}
+          {{- end }}
           env:
             - name: HANDLE_BROKER_MESSAGES
               value: "true"

--- a/charts/microservice/values.yaml
+++ b/charts/microservice/values.yaml
@@ -51,6 +51,22 @@ debug:
 ## serviceAccount: microservice-sa
 serviceAccount: default-sa
 
+## Graceful shutdown configuration.
+## During a rolling deploy, Kubernetes sends SIGTERM and removes the pod from
+## Service endpoints in parallel. Without coordination, the pod may exit before
+## the LB / API Gateway stops routing to it, causing in-flight requests to fail
+## with connection-refused / ECONNREFUSED. Pair `terminationGracePeriodSeconds`
+## with a `lifecycle.preStop` `sleep` to drain endpoints before the process exits.
+##
+## Example:
+## terminationGracePeriodSeconds: 60
+## lifecycle:
+##   preStop:
+##     exec:
+##       command: ["/bin/sh", "-c", "sleep 30"]
+terminationGracePeriodSeconds:
+lifecycle:
+
 ## Type of Kubernetes service to connect to the app. ClusterIP is the default, but all others are supported.
 ## Check https://kubernetes.io/docs/concepts/services-networking/service/
 service:


### PR DESCRIPTION
## Summary

- Adds two opt-in keys to the `microservice` chart so services can configure graceful shutdown for rolling deploys:
  - `terminationGracePeriodSeconds` (pod-spec level)
  - `lifecycle` (container-spec level — typically used for a `preStop` sleep)
- Both default to unset, so rendered manifests are byte-identical for existing values files that don't opt in. The same overrides are honored for the optional `worker` deployment via the existing `worker.*` `dig` pattern.
- Bumps chart version `1.12.0` → `1.13.0`.

## Why

During a rolling deploy, Kubernetes sends SIGTERM and removes the pod from Service endpoints **in parallel**. Without a `preStop` hook + grace period, the pod process exits before kube-proxy / API Gateway stops routing to it, so in-flight requests fail with `ECONNREFUSED` for the rest of the routing-propagation window. Clients see this as random network errors during every deploy (in browsers, the failed CORS preflight makes it look like a CORS bug).

Observed concretely on `credentialing-preprod`: ~4 deploys per 24h, each producing a 30–60s window of failing requests. The Datadog logs show only the SIGTERM and the next pod's fresh startup — no errors in between, because there *is* no error from the app's perspective; the pod is just gone.

The pattern matches the in-repo `nursa-api` chart, which already does this in its own `Deployments.yaml`:

```yaml
terminationGracePeriodSeconds: 60
lifecycle:
  preStop:
    exec:
      command: ["/bin/sh","-c","sleep 30"]
```

This PR brings the same capability to the shared `microservice` chart so services like `credentialing` (which depend on it) can opt in via values overrides.

## Test plan

- [ ] `helm lint charts/microservice` passes (couldn't run locally — no helm in env)
- [ ] `helm template charts/microservice` with no override of new keys → rendered manifest is byte-identical to `1.12.0` output (`diff` should be empty)
- [ ] `helm template charts/microservice --set terminationGracePeriodSeconds=60 --set 'lifecycle.preStop.exec.command={/bin/sh,-c,sleep 30}'` → both keys appear in the Deployment manifest at the correct indentation
- [ ] Same as above with `--set worker.enabled=true` → keys appear on the worker Deployment as well
- [ ] Override per-worker only (`--set worker.terminationGracePeriodSeconds=45`) → primary uses parent value (or unset), worker uses 45
- [ ] Follow-up: bump dep version in `apps/credentialing/ci-cd/helm/app/Chart.yaml` (monorepo) once 1.13.0 is published, then add the values overrides to `values-preprod.yaml` / `values-prod.yaml`.

[AI-assisted]