### PR TITLE
[DEVOPS-0] microservice 1.14.0: gate worker MPA on worker.mpa.enabled

### DIFF
--- a/charts/microservice/Chart.yaml
+++ b/charts/microservice/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: Microservice template
 name: microservice
-version: 1.13.0
+version: 1.14.0

--- a/charts/microservice/templates/mpa.yaml
+++ b/charts/microservice/templates/mpa.yaml
@@ -32,7 +32,12 @@ spec:
   policy:
     updateMode: Auto
 ---
-{{- if and (hasKey .Values "worker") .Values.worker.enabled }}
+{{/*
+  Worker MPA. Suppressed when worker.mpa.enabled is explicitly false — e.g. when
+  KEDA manages the worker's HPA (an MPA and an HPA cannot coexist on the same
+  Deployment). Defaults to true, so existing consumers are unaffected.
+*/}}
+{{- if and (hasKey .Values "worker") .Values.worker.enabled (ne (dig "mpa" "enabled" true .Values.worker) false) }}
 apiVersion: autoscaling.gke.io/v1beta1
 kind: MultidimPodAutoscaler
 metadata:


### PR DESCRIPTION
## What

Adds a `worker.mpa.enabled` toggle (default **true**) to the worker `MultidimPodAutoscaler` block in `microservice/templates/mpa.yaml`, and bumps the chart `1.13.0 → 1.14.0`.

## Why

Consumers want to hand the **worker** Deployment's horizontal scaling to **KEDA** (queue-depth driven). An MPA and a KEDA-managed HPA cannot coexist on the same Deployment, so KEDA users need a way to suppress the worker MPA. First consumer: marketplace preprod KEDA PoC (`nursa-monorepo#10269`).

## Change

```diff
-{{- if and (hasKey .Values "worker") .Values.worker.enabled }}
+{{- if and (hasKey .Values "worker") .Values.worker.enabled (ne (dig "mpa" "enabled" true .Values.worker) false) }}
```

## Backward compatibility ✅

Default is `true` via `dig`, so any consumer that does **not** set `worker.mpa.enabled` keeps the worker MPA exactly as today. Only an explicit `worker.mpa.enabled: false` suppresses it.

Verified by render:
- `worker.mpa.enabled=false` → worker MPA **suppressed** (count 0)
- key absent → worker MPA **rendered** (count 1, unchanged)
- `helm lint` passes

## Release

Merging to `main` triggers `chart_release.yaml` (chart-releaser) → publishes **1.14.0** to the helm repo. Downstream `marketplace` pins `microservice: 1.x`, so its CD picks up 1.14.0 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)