### PR TITLE
[DEVOPS-356] fix(microservice): tag worker pod logs as source:nestjs (1.15.0)

### DIFF
--- a/charts/microservice/Chart.yaml
+++ b/charts/microservice/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: Microservice template
 name: microservice
-version: 1.14.0
+version: 1.15.0

--- a/charts/microservice/templates/_helpers.tpl
+++ b/charts/microservice/templates/_helpers.tpl
@@ -57,6 +57,28 @@ timestamp: {{ now | unixEpoch | quote }}
   }]
 {{- end }}
 
+{{- /*
+  Worker pods run a container named "<release>-worker", so they need their own
+  Datadog log annotation keyed to that container name. Reusing common.annotations
+  (keyed to "<release>") silently no-ops on the worker container, which makes the
+  Datadog agent fall back to source:<image-name> instead of source:nestjs — the
+  NestJS pipeline never runs, debug logs are not status-remapped, and they leak
+  into the 30-day index. Mirror migration.annotations, which already does this.
+*/}}
+{{- define "worker.annotations" -}}
+timestamp: {{ now | unixEpoch | quote }}
+"ad.datadoghq.com/{{ include "appname" . }}-worker.logs": |-
+  [{
+    "source":"nestjs",
+    "log_processing_rules": [{
+    "type":"multi_line",
+    "name": "nest_start_line",
+    "pattern": "\\[Nest\\]"
+    }],
+    "tags":["pod_ip:%%host%%"]
+  }]
+{{- end }}
+
 {{- define "sa.annotations" -}}
 "iam.gke.io/gcp-service-account": {{ printf "%s@%s.iam.gserviceaccount.com" .Values.serviceAccount .Values.global.project_id | quote }}
 "helm.sh/hook": pre-install

--- a/charts/microservice/templates/_helpers.tpl
+++ b/charts/microservice/templates/_helpers.tpl
@@ -59,15 +59,18 @@ timestamp: {{ now | unixEpoch | quote }}
 
 {{- /*
   Worker pods run a container named "<release>-worker", so they need their own
-  Datadog log annotation keyed to that container name. Reusing common.annotations
-  (keyed to "<release>") silently no-ops on the worker container, which makes the
-  Datadog agent fall back to source:<image-name> instead of source:nestjs — the
-  NestJS pipeline never runs, debug logs are not status-remapped, and they leak
-  into the 30-day index. Mirror migration.annotations, which already does this.
+  Datadog log annotation keyed to that exact container name. Without a matching
+  key the agent falls back to source:<image-name> instead of source:nestjs — the
+  NestJS pipeline never runs, worker debug logs are not status-remapped, and they
+  leak into the 30-day index.
+
+  The key is built from .Release.Name (NOT the overrideName-aware "appname"
+  helper) so it always matches the worker container name, which deployments.yaml
+  hardcodes to "<.Release.Name>-worker" regardless of global.overrideName.
 */}}
 {{- define "worker.annotations" -}}
 timestamp: {{ now | unixEpoch | quote }}
-"ad.datadoghq.com/{{ include "appname" . }}-worker.logs": |-
+"ad.datadoghq.com/{{ .Release.Name }}-worker.logs": |-
   [{
     "source":"nestjs",
     "log_processing_rules": [{

--- a/charts/microservice/templates/deployments.yaml
+++ b/charts/microservice/templates/deployments.yaml
@@ -174,7 +174,7 @@ spec:
         tags.datadoghq.com/service: {{ .Release.Name }}-worker
         {{- include "worker.labels" . | nindent 8 }}
       annotations:
-        {{- include "common.annotations" . | nindent 8 }}
+        {{- include "worker.annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ default (include "appname" .) .Values.serviceAccount }}
       {{- $workerTerminationGrace := default .Values.terminationGracePeriodSeconds (dig "terminationGracePeriodSeconds" nil .Values.worker) }}


### PR DESCRIPTION
## Problem

Every IMS service's **worker** pod (`<svc>-worker`) ships its logs to Datadog tagged `source:<image-name>` instead of `source:nestjs`. That bypasses the NestJS log pipeline (which strips the `[Nest] … [Context]` prefix, parses the embedded JSON, and **status-remaps** from `level`/`severity`). With no remap, every worker DEBUG line defaults to `status:info` and lands in the **30-day `logs-45-days`** index instead of the 3-day debug index.

Confirmed affected (prod, June 22 volume in the 30-day index): `marketplace-worker` (3.7M/day), `notifications-worker` (653k), `feature-flags-worker` (489k), `public-api-worker` (244k), `webflow-worker` (228k), `rates-worker` (156k), `credentialing-worker` (120k), `auth-server-worker` (66k), `phoenix-worker` (16k).

Two impacts: **(1) Datadog cost** — millions of debug lines/day retained 30 days instead of 3; **(2) PII retention** — `notifications-worker` debug payloads contain unsanitized user PII (names, emails, phones, DOB, addresses), now held 30 days.

## Root cause

Both the main and worker Deployments attach pod annotations via `common.annotations`, which hardcodes the key to the **main** container name:

```
"ad.datadoghq.com/{{ include "appname" . }}.logs"   # appname = Release.Name, e.g. "marketplace"
```

Datadog log-autodiscovery annotations are keyed **by container name**. The main container is `<release>` (matches), but the worker container is `<release>-worker`, so `…/marketplace.logs` never matches the `marketplace-worker` container → the agent falls back to `source:<image>`. The migrator pod already avoids this via its own `migration.annotations` (`…-migrator.logs`); the worker pod was just never given the equivalent.

## Fix

- Add a `worker.annotations` helper keyed to `…/{{ include "appname" . }}-worker.logs` (mirrors `migration.annotations`: `source:nestjs` + the `[Nest]` multi_line rule).
- Point the worker Deployment's pod `annotations` at `worker.annotations` instead of `common.annotations`.
- Bump chart `1.14.0 → 1.15.0`.

Main pod and migrator pod are unchanged.

## Verification

`helm template` of the worker Deployment now renders:

```
"ad.datadoghq.com/marketplace-worker.logs": [{ "source":"nestjs", "log_processing_rules": [{ "type":"multi_line", "pattern":"\\[Nest\\]" }], ... }]
```

(matching the `marketplace-worker` container), while the main pod still renders `…/marketplace.logs`.

## Follow-up (separate monorepo PR, gated on this publishing)

The 8 consuming apps with a `Chart.lock` pinned to an older microservice version (`auth-server`, `credentialing`, `feature-flags`, `notifications`, `nursa-scraping`, `phoenix`, `rates`, `webflow`) must regen their lock (`helm dependency update`) to pull `1.15.0`. `marketplace` and `public-api` have no lock and will float to `1.15.0` automatically on next deploy.

Ref: DEVOPS-356
