### PR TITLE
[PAR-0] Add microservice=true label to app + worker pods

### DIFF
--- a/charts/microservice/Chart.yaml
+++ b/charts/microservice/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: Microservice template
 name: microservice
-version: 1.15.0
+version: 1.16.0

--- a/charts/microservice/templates/_helpers.tpl
+++ b/charts/microservice/templates/_helpers.tpl
@@ -22,12 +22,14 @@ version: {{ .Values.global.appVersion }}
 
 {{- define "app.labels" -}}
 {{- include "common.labels" . | trim }}
+microservice: "true"
 "tags.datadoghq.com/service": {{ include "appname" . }}
 "tags.datadoghq.com/version": {{ .Values.global.appVersion }}
 {{- end }}
 
 {{- define "worker.labels" -}}
 {{- include "common.labels" . | trim}}
+microservice: "true"
 "tags.datadoghq.com/service": {{ printf "%s-worker" (include "appname" .) }}
 "tags.datadoghq.com/version": {{ .Values.global.appVersion }}
 {{- end }}


### PR DESCRIPTION
## What
Adds `microservice: "true"` to the `app.labels` and `worker.labels` blocks in the shared `microservice` chart, so every service + worker pod rendered by this chart carries the label. Bumps the chart `1.15.0 → 1.16.0`.

## Why
Lets us group all backend microservices' logs in Coralogix with a single filter, instead of per-service parsing rules. The monorepo OTel collector surfaces this pod label as a `cx.microservice` resource attribute ([nursa-monorepo PR](https://github.com/nursa-com/nursa-monorepo/pull/10441)), after which backend logs are filterable via `resource.attributes."cx.microservice"`.

New microservices that depend on this chart, and their workers, are included automatically.

## Rollout
After merge + publish, each consuming app adopts it by bumping its `microservice` dependency in `Chart.lock` (the `version: 1.x` constraint alone won't pull it — CI uses `helm dep build` against the lock).